### PR TITLE
Update to latest version

### DIFF
--- a/Formula/cpdf.rb
+++ b/Formula/cpdf.rb
@@ -1,9 +1,9 @@
 class Cpdf < Formula
-  desc "Coherent PDF Command Line Tools give you a wide range of professional, robust tools to modify PDF files."
+  desc "Coherent PDF Command-line Tools to modify PDF files"
   homepage "https://www.coherentpdf.com/"
-  url "https://github.com/coherentgraphics/cpdf-binaries/raw/8e308f25a329e6ac3728a69afdc1ef531a24767c/OSX-Intel/cpdf"
-  version "2.2.1"
-  sha256 "4bb1893067e44d0aa8debda1ec1f24d3239c690c26fe950d79a5e3eadc5c723a"
+  url "https://github.com/coherentgraphics/cpdf-binaries/raw/11636b3a6578643c30e8f1cd91e53dd47f237b9d/OSX-Intel/cpdf"
+  version "2.3.1"
+  sha256 "7762cf030d289373f4364852e6caad00d8b88dceac1a0ce23c0e6a351d909eb3"
 
   bottle :unneeded
 


### PR DESCRIPTION
Version 2.3.1

Reason for some other changes:
Results of audit via  `brew audit --strict --online cpdf`

oncletom/brew/cpdf:
  * C: 1: col 1: Carriage return character detected.
  * C: 2: col 3: Description is too long. "name: desc" should be less than 80 characters. Length is calculated as cpdf + desc. (currently 110)
  * C: 2: col 112: Description shouldn't end with a full stop